### PR TITLE
Update top-nav-widget ms class in functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -123,7 +123,7 @@ if (!function_exists('bootscore_widgets_init')) :
       'name'          => esc_html__('Top Nav', 'bootscore'),
       'id'            => 'top-nav',
       'description'   => esc_html__('Add widgets here.', 'bootscore'),
-      'before_widget' => '<div class="top-nav-widget ms-2">',
+      'before_widget' => '<div class="top-nav-widget ms-1 ms-md-2">',
       'after_widget'  => '</div>',
       'before_title'  => '<div class="widget-title d-none">',
       'after_title'   => '</div>'


### PR DESCRIPTION
Changing `ms-2` to `ms-1 ms-md-2` in top-nav-widget.  So if we would add items or buttons via wordpress admin panel to the `top-nav`, one after another in different `HTML-code` containers, we would keep 0.25rem margin between them on mobile screens instead of ms-2, which would look too wide compared to margin between other elements (navbar-toggler, cart, user). So we won't see this:)
<img width="478" alt="123" src="https://github.com/exlexv/bootscore/assets/108526222/6cb0a69a-b1f7-4fe0-847f-e32aa4b322af">
